### PR TITLE
Ex25 team1 ashley fix mentor assignments

### DIFF
--- a/ui_tests/package-lock.json
+++ b/ui_tests/package-lock.json
@@ -17,7 +17,7 @@
         "@playwright/test": "^1.58.2",
         "@types/node": "^20.14.9",
         "cross-env": "^7.0.3",
-        "dotenv": "^17.3.1",
+        "dotenv": "^17.4.2",
         "husky": "^9.1.7",
         "prettier": "^3.3.2",
         "ts-node": "^10.9.2",
@@ -25,13 +25,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -74,30 +74,30 @@
       }
     },
     "node_modules/@cucumber/ci-environment": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/ci-environment/-/ci-environment-10.0.1.tgz",
-      "integrity": "sha512-/+ooDMPtKSmvcPMDYnMZt4LuoipfFfHaYspStI4shqw8FyKcfQAmekz6G+QKWjQQrvM+7Hkljwx58MEwPCwwzg==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/ci-environment/-/ci-environment-13.0.0.tgz",
+      "integrity": "sha512-cs+3NzfNkGbcmHPddjEv4TKFiBpZRQ6WJEEufB9mw+ExS22V/4R/zpDSEG+fsJ/iSNCd6A2sATdY8PFOyY3YnA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cucumber/cucumber": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-12.2.0.tgz",
-      "integrity": "sha512-b7W4snvXYi1T2puUjxamASCCNhNzVSzb/fQUuGSkdjm/AFfJ24jo8kOHQyOcaoArCG71sVQci4vkZaITzl/V1w==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-12.9.0.tgz",
+      "integrity": "sha512-QbgEo/DcKFMRGL+yULh8Kw6peEfdPJjhYjpKp0dYc+6Dv1Bmp6hvxIdTi2CIinYBCXhvCZzNO1Ct/n6Dk1yAtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cucumber/ci-environment": "10.0.1",
-        "@cucumber/cucumber-expressions": "18.0.1",
-        "@cucumber/gherkin": "34.0.0",
-        "@cucumber/gherkin-streams": "5.0.1",
-        "@cucumber/gherkin-utils": "9.2.0",
-        "@cucumber/html-formatter": "21.14.0",
-        "@cucumber/junit-xml-formatter": "0.8.1",
-        "@cucumber/message-streams": "4.0.1",
-        "@cucumber/messages": "28.1.0",
+        "@cucumber/ci-environment": "13.0.0",
+        "@cucumber/cucumber-expressions": "19.0.0",
+        "@cucumber/gherkin": "38.0.0",
+        "@cucumber/gherkin-streams": "6.0.0",
+        "@cucumber/gherkin-utils": "11.0.0",
+        "@cucumber/html-formatter": "23.1.0",
+        "@cucumber/junit-xml-formatter": "0.13.3",
+        "@cucumber/message-streams": "4.1.1",
+        "@cucumber/messages": "32.3.1",
         "@cucumber/pretty-formatter": "1.0.1",
-        "@cucumber/tag-expressions": "6.2.0",
+        "@cucumber/tag-expressions": "9.1.0",
         "assertion-error-formatter": "^3.0.0",
         "capital-case": "^1.0.4",
         "chalk": "^4.1.2",
@@ -106,7 +106,7 @@
         "debug": "^4.3.4",
         "error-stack-parser": "^2.1.4",
         "figures": "^3.2.0",
-        "glob": "^11.0.0",
+        "glob": "^13.0.0",
         "has-ansi": "^4.0.1",
         "indent-string": "^4.0.0",
         "is-installed-globally": "^0.4.0",
@@ -114,19 +114,18 @@
         "knuth-shuffle-seeded": "^1.0.6",
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
-        "luxon": "3.7.1",
-        "mime": "^3.0.0",
+        "luxon": "3.7.2",
         "mkdirp": "^3.0.0",
         "mz": "^2.7.0",
         "progress": "^2.0.3",
-        "read-package-up": "^11.0.0",
-        "semver": "7.7.2",
+        "read-package-up": "^12.0.0",
+        "semver": "7.7.4",
         "string-argv": "0.3.1",
         "supports-color": "^8.1.1",
         "type-fest": "^4.41.0",
         "util-arity": "^1.1.0",
         "yaml": "^2.2.2",
-        "yup": "1.7.0"
+        "yup": "1.7.1"
       },
       "bin": {
         "cucumber-js": "bin/cucumber.js"
@@ -139,9 +138,9 @@
       }
     },
     "node_modules/@cucumber/cucumber-expressions": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-18.0.1.tgz",
-      "integrity": "sha512-NSid6bI+7UlgMywl5octojY5NXnxR9uq+JisjOrO52VbFsQM6gTWuQFE8syI10KnIBEdPzuEUSVEeZ0VFzRnZA==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-19.0.0.tgz",
+      "integrity": "sha512-4FKoOQh2Uf6F6/Ln+1OxuK8LkTg6PyAqekhf2Ix8zqV2M54sH+m7XNJNLhOFOAW/t9nxzRbw2CcvXbCLjcvHZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -149,23 +148,23 @@
       }
     },
     "node_modules/@cucumber/gherkin": {
-      "version": "34.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-34.0.0.tgz",
-      "integrity": "sha512-659CCFsrsyvuBi/Eix1fnhSheMnojSfnBcqJ3IMPNawx7JlrNJDcXYSSdxcUw3n/nG05P+ptCjmiZY3i14p+tA==",
+      "version": "38.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-38.0.0.tgz",
+      "integrity": "sha512-duEXK+KDfQUzu3vsSzXjkxQ2tirF5PRsc1Xrts6THKHJO6mjw4RjM8RV+vliuDasmhhrmdLcOcM7d9nurNTJKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cucumber/messages": ">=19.1.4 <29"
+        "@cucumber/messages": ">=31.0.0 <33"
       }
     },
     "node_modules/@cucumber/gherkin-streams": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-streams/-/gherkin-streams-5.0.1.tgz",
-      "integrity": "sha512-/7VkIE/ASxIP/jd4Crlp4JHXqdNFxPGQokqWqsaCCiqBiu5qHoKMxcWNlp9njVL/n9yN4S08OmY3ZR8uC5x74Q==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-streams/-/gherkin-streams-6.0.0.tgz",
+      "integrity": "sha512-HLSHMmdDH0vCr7vsVEURcDA4WwnRLdjkhqr6a4HQ3i4RFK1wiDGPjBGVdGJLyuXuRdJpJbFc6QxHvT8pU4t6jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "9.1.0",
+        "commander": "14.0.0",
         "source-map-support": "0.5.21"
       },
       "bin": {
@@ -178,110 +177,36 @@
       }
     },
     "node_modules/@cucumber/gherkin-streams/node_modules/commander": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.1.0.tgz",
-      "integrity": "sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || >=14"
+        "node": ">=20"
       }
     },
     "node_modules/@cucumber/gherkin-utils": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-9.2.0.tgz",
-      "integrity": "sha512-3nmRbG1bUAZP3fAaUBNmqWO0z0OSkykZZotfLjyhc8KWwDSOrOmMJlBTd474lpA8EWh4JFLAX3iXgynBqBvKzw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-11.0.0.tgz",
+      "integrity": "sha512-LJ+s4+TepHTgdKWDR4zbPyT7rQjmYIcukTwNbwNwgqr6i8Gjcmzf6NmtbYDA19m1ZFg6kWbFsmHnj37ZuX+kZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cucumber/gherkin": "^31.0.0",
-        "@cucumber/messages": "^27.0.0",
+        "@cucumber/gherkin": "^38.0.0",
+        "@cucumber/messages": "^32.0.0",
         "@teppeis/multimaps": "3.0.0",
-        "commander": "13.1.0",
+        "commander": "14.0.2",
         "source-map-support": "^0.5.21"
       },
       "bin": {
         "gherkin-utils": "bin/gherkin-utils"
       }
     },
-    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin": {
-      "version": "31.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-31.0.0.tgz",
-      "integrity": "sha512-wlZfdPif7JpBWJdqvHk1Mkr21L5vl4EfxVUOS4JinWGf3FLRV6IKUekBv5bb5VX79fkDcfDvESzcQ8WQc07Wgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cucumber/messages": ">=19.1.4 <=26"
-      }
-    },
-    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin/node_modules/@cucumber/messages": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-26.0.1.tgz",
-      "integrity": "sha512-DIxSg+ZGariumO+Lq6bn4kOUIUET83A4umrnWmidjGFl8XxkBieUZtsmNbLYgH/gnsmP07EfxxdTr0hOchV1Sg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/uuid": "10.0.0",
-        "class-transformer": "0.5.1",
-        "reflect-metadata": "0.2.2",
-        "uuid": "10.0.0"
-      }
-    },
-    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/messages": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-27.2.0.tgz",
-      "integrity": "sha512-f2o/HqKHgsqzFLdq6fAhfG1FNOQPdBdyMGpKwhb7hZqg0yZtx9BVqkTyuoNk83Fcvk3wjMVfouFXXHNEk4nddA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/uuid": "10.0.0",
-        "class-transformer": "0.5.1",
-        "reflect-metadata": "0.2.2",
-        "uuid": "11.0.5"
-      }
-    },
-    "node_modules/@cucumber/gherkin-utils/node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@cucumber/gherkin-utils/node_modules/uuid": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
-      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@cucumber/html-formatter": {
-      "version": "21.14.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-21.14.0.tgz",
-      "integrity": "sha512-vQqbmQZc0QiN4c+cMCffCItpODJlOlYtPG7pH6We096dBOa7u0ttDMjT6KrMAnQlcln54rHL46r408IFpuznAw==",
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-23.1.0.tgz",
+      "integrity": "sha512-DcCSFoGs6jbwzXPgX1CwgJKEE+ZMcIEzq/0Memg0o24maNn9NJizBFHmoFWG4iv/OxHza+mvc+56cTHetfHndw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -289,13 +214,13 @@
       }
     },
     "node_modules/@cucumber/junit-xml-formatter": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/junit-xml-formatter/-/junit-xml-formatter-0.8.1.tgz",
-      "integrity": "sha512-FT1Y96pyd9/ifbE9I7dbkTCjkwEdW9C0MBobUZoKD13c8EnWAt0xl1Yy/v/WZLTk4XfCLte1DATtLx01jt+YiA==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@cucumber/junit-xml-formatter/-/junit-xml-formatter-0.13.3.tgz",
+      "integrity": "sha512-w9ujOxiuKDtU6fLzJz+wp4Sgp5Xu6ba7ls00LHJccVmQU0Ba7zs+AHnv3iIgPjKZAQe1w8x93dr8Gaubh7Vqkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cucumber/query": "^13.0.2",
+        "@cucumber/query": "^15.0.1",
         "@teppeis/multimaps": "^3.0.0",
         "luxon": "^3.5.0",
         "xmlbuilder": "^15.1.1"
@@ -305,26 +230,27 @@
       }
     },
     "node_modules/@cucumber/message-streams": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/message-streams/-/message-streams-4.0.1.tgz",
-      "integrity": "sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/message-streams/-/message-streams-4.1.1.tgz",
+      "integrity": "sha512-QCAntLajesWMyX+mZKrj63YghVAts7yKFlZe46XprLbdJZN0ddB+f/Mr9OnyWKC2DHhJ18jzCfKIFCaqpAmUxg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
       "peerDependencies": {
         "@cucumber/messages": ">=17.1.1"
       }
     },
     "node_modules/@cucumber/messages": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-28.1.0.tgz",
-      "integrity": "sha512-2LzZtOwYKNlCuNf31ajkrekoy2M4z0Z1QGiPH40n4gf5t8VOUFb7m1ojtR4LmGvZxBGvJZP8voOmRqDWzBzYKA==",
+      "version": "32.3.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-32.3.1.tgz",
+      "integrity": "sha512-yNQq1KoXRYaEKrWMFmpUQX7TdeQuU9jeGgJAZ3dArTsC/T4NpJ6DnqaJIIgwPnz/wtQIQTNX7/h0rOuF5xY4qQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/uuid": "10.0.0",
         "class-transformer": "0.5.1",
-        "reflect-metadata": "0.2.2",
-        "uuid": "11.1.0"
+        "reflect-metadata": "0.2.2"
       }
     },
     "node_modules/@cucumber/pretty-formatter": {
@@ -345,9 +271,9 @@
       }
     },
     "node_modules/@cucumber/query": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/query/-/query-13.6.0.tgz",
-      "integrity": "sha512-tiDneuD5MoWsJ9VKPBmQok31mSX9Ybl+U4wqDoXeZgsXHDURqzM3rnpWVV3bC34y9W6vuFxrlwF/m7HdOxwqRw==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/query/-/query-15.0.1.tgz",
+      "integrity": "sha512-FMfT3orJblRsOxvU2doECBvQmauizYlj+5JsM8atAKKPbnQTj7v2/OrnuykvQpfZNBf19DYbRq1e832vllRP/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -359,77 +285,11 @@
       }
     },
     "node_modules/@cucumber/tag-expressions": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-6.2.0.tgz",
-      "integrity": "sha512-KIF0eLcafHbWOuSDWFw0lMmgJOLdDRWjEL1kfXEWrqHmx2119HxVAr35WuEd9z542d3Yyg+XNqSr+81rIKqEdg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-9.1.0.tgz",
+      "integrity": "sha512-bvHjcRFZ+J1TqIa9eFNO1wGHqwx4V9ZKV3hYgkuK/VahHx73uiP4rKV3JVrvWSMrwrFvJG6C8aEwnCWSvbyFdQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
@@ -530,13 +390,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -610,6 +463,29 @@
         "diff": "^4.0.1",
         "pad-right": "^0.2.2",
         "repeat-string": "^1.6.1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/buffer-from": {
@@ -790,9 +666,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -800,9 +676,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -811,13 +687,6 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
-    },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -875,23 +744,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -907,24 +759,18 @@
       }
     },
     "node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -970,24 +816,17 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "lru-cache": "^10.0.1"
+        "lru-cache": "^11.1.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
-    },
-    "node_modules/hosted-git-info/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/husky": {
       "version": "9.1.7",
@@ -1095,22 +934,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/jackspeak": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1160,19 +983,19 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/luxon": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.1.tgz",
-      "integrity": "sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1200,27 +1023,27 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -1272,18 +1095,18 @@
       }
     },
     "node_modules/normalize-package-data": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+      "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "hosted-git-info": "^7.0.0",
+        "hosted-git-info": "^9.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/object-assign": {
@@ -1295,13 +1118,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
     },
     "node_modules/pad-right": {
       "version": "0.2.2",
@@ -1345,9 +1161,9 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1355,7 +1171,7 @@
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1432,38 +1248,70 @@
       "license": "MIT"
     },
     "node_modules/read-package-up": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
-      "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-12.0.0.tgz",
+      "integrity": "sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "find-up-simple": "^1.0.0",
-        "read-pkg": "^9.0.0",
-        "type-fest": "^4.6.0"
+        "find-up-simple": "^1.0.1",
+        "read-pkg": "^10.0.0",
+        "type-fest": "^5.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-package-up/node_modules/type-fest": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
-      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.1.0.tgz",
+      "integrity": "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/normalize-package-data": "^2.4.3",
-        "normalize-package-data": "^6.0.0",
-        "parse-json": "^8.0.0",
-        "type-fest": "^4.6.0",
-        "unicorn-magic": "^0.1.0"
+        "@types/normalize-package-data": "^2.4.4",
+        "normalize-package-data": "^8.0.0",
+        "parse-json": "^8.3.0",
+        "type-fest": "^5.4.4",
+        "unicorn-magic": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1514,9 +1362,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1547,19 +1395,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/source-map": {
@@ -1613,9 +1448,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -1651,45 +1486,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1713,59 +1509,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -1780,6 +1523,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/thenify": {
@@ -1915,13 +1671,13 @@
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1943,20 +1699,6 @@
       "integrity": "sha512-kkyIsXKwemfSy8ZEoaIz06ApApnWsk5hQO0vLjZS6UkBiGiW++Jsyb8vSBoc0WKlffGoGs5yYy/j5pp8zckrFA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -1992,120 +1734,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -2117,9 +1745,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2127,6 +1755,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yn": {
@@ -2140,9 +1771,9 @@
       }
     },
     "node_modules/yup": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.0.tgz",
-      "integrity": "sha512-VJce62dBd+JQvoc+fCVq+KZfPHr+hXaxCcVgotfwWvlR0Ja3ffYKaJBT8rptPOSKOGJDCUnW2C2JWpud7aRP6Q==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.1.tgz",
+      "integrity": "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ui_tests/package.json
+++ b/ui_tests/package.json
@@ -21,7 +21,7 @@
     "@playwright/test": "^1.58.2",
     "@types/node": "^20.14.9",
     "cross-env": "^7.0.3",
-    "dotenv": "^17.3.1",
+    "dotenv": "^17.4.2",
     "husky": "^9.1.7",
     "prettier": "^3.3.2",
     "ts-node": "^10.9.2",

--- a/ui_tests/src/pages/admin/AdminDashboardPage.ts
+++ b/ui_tests/src/pages/admin/AdminDashboardPage.ts
@@ -4,13 +4,11 @@ import * as env from '../../config/world';
 export class AdminDashboardPage {
   readonly page: Page;
 
-
   constructor(page: Page) {
     this.page = page;
   }
 
   async waitForDashboard(timeout = 40000) {
-    await expect(this.page.locator('h1:has-text("Admin")')).toBeVisible({ timeout });
+    await expect(this.page.locator('h1')).toContainText(/Good (morning|afternoon|evening)/i, { timeout });
   }
 }
-

--- a/ui_tests/src/pages/admin/AssignmentPage.ts
+++ b/ui_tests/src/pages/admin/AssignmentPage.ts
@@ -58,6 +58,7 @@ export class AssignmentPage extends BasePage {
         await studentOption.scrollIntoViewIfNeeded();
         await studentOption.click();
     }
+    
 // Verify that no assignment was created
     async verifyNoAssignments() {
         // Verify button is disabled

--- a/ui_tests/src/pages/admin/AssignmentPage.ts
+++ b/ui_tests/src/pages/admin/AssignmentPage.ts
@@ -2,131 +2,163 @@ import { Page, expect } from '@playwright/test';
 import * as env from '../../config/world';
 import { BasePage } from '../common/BasePage';
 
-
-// Page Object Model (POM) class for the AssignmentPage
 export class AssignmentPage extends BasePage {
-    // Constructor to initialize the page object
     constructor(page: Page) {
         super(page);
     }
 
-// Navigate to the Mentor Assignments section
     async goToAssignments() {
         await this.page.goto(`${env.getBaseUrl()}/admin/mentor-assignments`);
         await this.page.waitForLoadState('networkidle');
     }
 
     async waitForDashboard(timeout = 40000) {
-        await expect(this.page.locator('h1:has-text("Admin")')).toBeVisible({ timeout });
-  }
+        await expect(this.page.locator('h1')).toContainText(/Good (morning|afternoon|evening)/i, { timeout });
+    }
 
-// Create a new mentor-student assignment
     async assignStudentToMentor(studentText: string, mentorText: string) {
         // Select student
-        this.page.locator('#studentId').click();
-        const studentOption = this.page.locator('li[role="option"]', { hasText: studentText });
-        await studentOption.scrollIntoViewIfNeeded();
+        const studentInput = this.page.getByRole('combobox', { name: /select students/i });
+        await studentInput.click();
+        await studentInput.fill(studentText);
+
+        const studentOption = this.page.locator('li[role="option"]').filter({
+            hasText: studentText,
+        });
+
+        await expect(studentOption).toBeVisible({ timeout: 10000 });
         await studentOption.click();
-        // Select mentor
-        await this.page.locator('#mentorId').click();
-        const mentorOption = this.page.locator('li[role="option"]', { hasText: mentorText });
-        await mentorOption.scrollIntoViewIfNeeded();
+
+        // Select mentor / career coach
+        const mentorInput = this.page.getByRole('combobox', { name: /career coach/i });
+        await mentorInput.click();
+        await mentorInput.fill(mentorText);
+
+        const mentorOption = this.page.locator('li[role="option"]').filter({
+            hasText: mentorText,
+        });
+
+        await expect(mentorOption).toBeVisible({ timeout: 10000 });
         await mentorOption.click();
+
         // Click create
         await this.page.getByRole('button', { name: 'Create Assignment' }).click();
     }
-// Verify that the assignment was created successfully
+
     async verifyAssignmentCreated() {
-        await expect(this.page.getByText('Mentor Assignment created')).toBeVisible();
+        await expect(
+            this.page.getByText(/Mentor Assignment created|created successfully|successfully/i)
+        ).toBeVisible({ timeout: 10000 });
     }
-// Verify that the new assignment appears in the assignments list
-    async verifyDisplay() {
-        await this.page.getByRole('cell', { name: 'Eric Hibbard eric.hibbard91+' });
-        
+
+    async verifyDisplay(studentText: string) {
+        await expect(this.page.getByText(studentText)).toBeVisible();
     }
-// Remove assignment to maintain test isolation
+
     async removeAssignment(studentName: string) {
         const row = this.page.locator(`tr:has-text("${studentName}")`);
-        // Finds row with specific student name and clicks remove button
         await row.locator('button:has-text("Remove")').click();
+
+        const confirmButton = this.page.getByRole('button', { name: /confirm|remove|yes/i });
+
+        if (await confirmButton.isVisible().catch(() => false)) {
+            await confirmButton.click();
+        }
     }
-// Attempt to create assignment without selecting a mentor
+
+    async removeAssignmentIfExists(studentName: string) {
+        const row = this.page.locator(`tr:has-text("${studentName}")`);
+        const rowCount = await row.count();
+
+        if (rowCount > 0) {
+            await row.first().locator('button:has-text("Remove")').click();
+
+            const confirmButton = this.page.getByRole('button', { name: /confirm|remove|yes/i });
+
+            if (await confirmButton.isVisible().catch(() => false)) {
+                await confirmButton.click();
+            }
+
+            await expect(row.first()).not.toBeVisible({ timeout: 10000 });
+        }
+    }
+
     async assignmentMissingMentor(studentText: string) {
-        // Select student only
-        this.page.locator('#studentId').click();
-        const studentOption = this.page.locator('li[role="option"]', { hasText: studentText });
-        await studentOption.scrollIntoViewIfNeeded();
+        const studentInput = this.page.getByRole('combobox', { name: /select students/i });
+        await studentInput.click();
+        await studentInput.fill(studentText);
+
+        const studentOption = this.page.locator('li[role="option"]').filter({
+            hasText: studentText,
+        });
+
+        await expect(studentOption).toBeVisible({ timeout: 10000 });
         await studentOption.click();
     }
-    
-// Verify that no assignment was created
-    async verifyNoAssignments() {
-        // Verify button is disabled
-        const createButton = this.page.locator('button:has-text("Create Assignment")');
+
+    async verifyNoAssignments(studentName: string) {
+        const createButton = this.page.getByRole('button', { name: 'Create Assignment' });
         await expect(createButton).toBeDisabled();
-        // Verify student is NOT in the table
-        const row = await this.page.locator('tr:has-text("Student Name")').count();
+
+        const row = await this.page.locator(`tr:has-text("${studentName}")`).count();
         expect(row).toBe(0);
     }
 
     async checkAssignmentIssues(studentName: string, mentorName: string) {
-        // Checks for All Students have mentors assigned message. Msg disables check assignment issues button
-        
         const satisfiedMessage = this.page.getByText(
-        'All students have mentors assigned with complete information!'
-    );
+            'All students have mentors assigned with complete information!'
+        );
+
         await satisfiedMessage.first().waitFor({ timeout: 3000 }).catch(() => {});
-    // Guard clause: if UI already shows all assigned, skip assignment
+
         if (await satisfiedMessage.isVisible()) {
-            return;
-    } 
-        // Finds and clicks Check Assignment Issues button to reveal table
-        await this.page.getByRole('button', { name: 'Check Assignment Issues' }).click();       
-        // Locate the student row
+            return 'all-complete';
+        }
+
+        await this.page.getByRole('button', { name: 'Check Assignment Issues' }).click();
+
         const studentRow = this.page.locator(`li:has(span:text("${studentName}"))`);
         await studentRow.scrollIntoViewIfNeeded();
-        // Locate the dropdown inside that row and click to open
+
         const dropdown = studentRow.locator('div[role="combobox"]');
         await dropdown.click();
-        // Select mentor from dropdown
+
         const mentorOption = this.page.locator(`li[role="option"]:has-text("${mentorName}")`);
         await mentorOption.scrollIntoViewIfNeeded();
         await mentorOption.click();
+
         const assignMentorButton = studentRow.getByRole('button', { name: 'Assign Mentor' });
         await expect(assignMentorButton).toBeEnabled();
         await assignMentorButton.click();
+
         return 'assigned';
-    } 
+    }
 
     async verifyAssignmentIssue() {
-        const createdMessage = this.page.getByText('Mentor Assignment created successfully');
+        const createdMessage = this.page.getByText(/Mentor Assignment created successfully|created successfully/i);
         const allAssignedMessage = this.page.getByText(
-        'All students have mentors assigned with complete information!'
-    );
+            'All students have mentors assigned with complete information!'
+        );
 
         if (await allAssignedMessage.isVisible()) {
-        await expect(allAssignedMessage).toBeVisible();
+            await expect(allAssignedMessage).toBeVisible();
         } else {
             await expect(createdMessage).toBeVisible();
+        }
     }
-}
-   
 
     async verifyTableDisplay() {
-    // Verify that table displays existing assignments
         const tableRows = this.page.locator('table tbody tr');
         const rowCount = await tableRows.count();
         expect(rowCount).toBeGreaterThan(0);
     }
 
     async verifyColumnHeaders() {
-    // Verify that the table contains the correct columns
         const headers = this.page.locator('tr.MuiTableRow-head th.MuiTableCell-head');
-    // Collect the visible text of all headers
         const headerTexts = await headers.allTextContents();
-    // Assert the required columns are present
+
         expect(headerTexts).toContain('Student');
-        expect(headerTexts).toContain('Mentor');
+        expect(headerTexts).toContain('Career Coach');
         expect(headerTexts).toContain('Status');
         expect(headerTexts).toContain('Assigned Date');
     }

--- a/ui_tests/src/pages/admin/AssignmentPage.ts
+++ b/ui_tests/src/pages/admin/AssignmentPage.ts
@@ -19,6 +19,8 @@ export class AssignmentPage extends BasePage {
     async assignStudentToMentor(studentText: string, mentorText: string) {
         // Select student
         const studentInput = this.page.getByRole('combobox', { name: /select students/i });
+
+        await expect(studentInput).toBeVisible({ timeout: 10000 });
         await studentInput.click();
         await studentInput.fill(studentText);
 
@@ -26,11 +28,13 @@ export class AssignmentPage extends BasePage {
             hasText: studentText,
         });
 
-        await expect(studentOption).toBeVisible({ timeout: 10000 });
-        await studentOption.click();
+        await expect(studentOption.first()).toBeVisible({ timeout: 10000 });
+        await studentOption.first().click();
 
         // Select mentor / career coach
         const mentorInput = this.page.getByRole('combobox', { name: /career coach/i });
+
+        await expect(mentorInput).toBeVisible({ timeout: 10000 });
         await mentorInput.click();
         await mentorInput.fill(mentorText);
 
@@ -38,11 +42,59 @@ export class AssignmentPage extends BasePage {
             hasText: mentorText,
         });
 
-        await expect(mentorOption).toBeVisible({ timeout: 10000 });
-        await mentorOption.click();
+        await expect(mentorOption.first()).toBeVisible({ timeout: 10000 });
+        await mentorOption.first().click();
 
         // Click create
-        await this.page.getByRole('button', { name: 'Create Assignment' }).click();
+        const createButton = this.page.getByRole('button', { name: 'Create Assignment' });
+
+        await expect(createButton).toBeVisible({ timeout: 10000 });
+        await expect(createButton).toBeEnabled({ timeout: 10000 });
+        await createButton.click();
+    }
+
+    async assignFirstAvailableStudentToMentor(mentorText: string) {
+        // Select first available student instead of hardcoding one name
+        const studentInput = this.page.getByRole('combobox', { name: /select students/i });
+
+        await expect(studentInput).toBeVisible({ timeout: 10000 });
+        await studentInput.click();
+
+        const studentOptions = this.page.locator('li[role="option"]');
+        await expect(studentOptions.first()).toBeVisible({ timeout: 10000 });
+
+        const selectedStudentOptionText = await studentOptions.first().innerText();
+
+        const selectedStudent = selectedStudentOptionText
+            .split('\n')
+            .map((text) => text.trim())
+            .filter(Boolean)
+            .pop()!;
+
+        await studentOptions.first().click();
+
+        // Select mentor / career coach
+        const mentorInput = this.page.getByRole('combobox', { name: /career coach/i });
+
+        await expect(mentorInput).toBeVisible({ timeout: 10000 });
+        await mentorInput.click();
+        await mentorInput.fill(mentorText);
+
+        const mentorOption = this.page.locator('li[role="option"]').filter({
+            hasText: mentorText,
+        });
+
+        await expect(mentorOption.first()).toBeVisible({ timeout: 10000 });
+        await mentorOption.first().click();
+
+        // Click create
+        const createButton = this.page.getByRole('button', { name: 'Create Assignment' });
+
+        await expect(createButton).toBeVisible({ timeout: 10000 });
+        await expect(createButton).toBeEnabled({ timeout: 10000 });
+        await createButton.click();
+
+        return selectedStudent;
     }
 
     async verifyAssignmentCreated() {
@@ -52,12 +104,21 @@ export class AssignmentPage extends BasePage {
     }
 
     async verifyDisplay(studentText: string) {
-        await expect(this.page.getByText(studentText)).toBeVisible();
+        const row = this.page.locator('table tbody tr').filter({
+            hasText: studentText,
+        });
+
+        await expect(row.first()).toBeVisible({ timeout: 10000 });
     }
 
     async removeAssignment(studentName: string) {
-        const row = this.page.locator(`tr:has-text("${studentName}")`);
-        await row.locator('button:has-text("Remove")').click();
+        const row = this.page.locator('table tbody tr').filter({
+            hasText: studentName,
+        });
+
+        await expect(row.first()).toBeVisible({ timeout: 10000 });
+
+        await row.first().locator('button:has-text("Remove")').click();
 
         const confirmButton = this.page.getByRole('button', { name: /confirm|remove|yes/i });
 
@@ -67,7 +128,10 @@ export class AssignmentPage extends BasePage {
     }
 
     async removeAssignmentIfExists(studentName: string) {
-        const row = this.page.locator(`tr:has-text("${studentName}")`);
+        const row = this.page.locator('table tbody tr').filter({
+            hasText: studentName,
+        });
+
         const rowCount = await row.count();
 
         if (rowCount > 0) {
@@ -85,6 +149,8 @@ export class AssignmentPage extends BasePage {
 
     async assignmentMissingMentor(studentText: string) {
         const studentInput = this.page.getByRole('combobox', { name: /select students/i });
+
+        await expect(studentInput).toBeVisible({ timeout: 10000 });
         await studentInput.click();
         await studentInput.fill(studentText);
 
@@ -92,16 +158,19 @@ export class AssignmentPage extends BasePage {
             hasText: studentText,
         });
 
-        await expect(studentOption).toBeVisible({ timeout: 10000 });
-        await studentOption.click();
+        await expect(studentOption.first()).toBeVisible({ timeout: 10000 });
+        await studentOption.first().click();
     }
 
     async verifyNoAssignments(studentName: string) {
         const createButton = this.page.getByRole('button', { name: 'Create Assignment' });
         await expect(createButton).toBeDisabled();
 
-        const row = await this.page.locator(`tr:has-text("${studentName}")`).count();
-        expect(row).toBe(0);
+        const row = this.page.locator('table tbody tr').filter({
+            hasText: studentName,
+        });
+
+        await expect(row).toHaveCount(0);
     }
 
     async checkAssignmentIssues(studentName: string, mentorName: string) {
@@ -111,24 +180,32 @@ export class AssignmentPage extends BasePage {
 
         await satisfiedMessage.first().waitFor({ timeout: 3000 }).catch(() => {});
 
-        if (await satisfiedMessage.isVisible()) {
+        if (await satisfiedMessage.isVisible().catch(() => false)) {
             return 'all-complete';
         }
 
         await this.page.getByRole('button', { name: 'Check Assignment Issues' }).click();
 
-        const studentRow = this.page.locator(`li:has(span:text("${studentName}"))`);
-        await studentRow.scrollIntoViewIfNeeded();
+        const studentRow = this.page.locator('li').filter({
+            has: this.page.locator('span', { hasText: studentName }),
+        });
 
-        const dropdown = studentRow.locator('div[role="combobox"]');
+        await expect(studentRow.first()).toBeVisible({ timeout: 10000 });
+        await studentRow.first().scrollIntoViewIfNeeded();
+
+        const dropdown = studentRow.first().locator('div[role="combobox"]');
         await dropdown.click();
 
-        const mentorOption = this.page.locator(`li[role="option"]:has-text("${mentorName}")`);
-        await mentorOption.scrollIntoViewIfNeeded();
-        await mentorOption.click();
+        const mentorOption = this.page.locator('li[role="option"]').filter({
+            hasText: mentorName,
+        });
 
-        const assignMentorButton = studentRow.getByRole('button', { name: 'Assign Mentor' });
-        await expect(assignMentorButton).toBeEnabled();
+        await expect(mentorOption.first()).toBeVisible({ timeout: 10000 });
+        await mentorOption.first().scrollIntoViewIfNeeded();
+        await mentorOption.first().click();
+
+        const assignMentorButton = studentRow.first().getByRole('button', { name: 'Assign Mentor' });
+        await expect(assignMentorButton).toBeEnabled({ timeout: 10000 });
         await assignMentorButton.click();
 
         return 'assigned';
@@ -140,10 +217,10 @@ export class AssignmentPage extends BasePage {
             'All students have mentors assigned with complete information!'
         );
 
-        if (await allAssignedMessage.isVisible()) {
+        if (await allAssignedMessage.isVisible().catch(() => false)) {
             await expect(allAssignedMessage).toBeVisible();
         } else {
-            await expect(createdMessage).toBeVisible();
+            await expect(createdMessage).toBeVisible({ timeout: 10000 });
         }
     }
 

--- a/ui_tests/tests/mentor/mentorAssignments.spec.ts
+++ b/ui_tests/tests/mentor/mentorAssignments.spec.ts
@@ -1,101 +1,68 @@
+import { expect, test } from '@playwright/test';
 
-// Import Playwright classes and assertion utilities
-import { chromium, Browser, Page, expect, test } from '@playwright/test';
-
-// Import environment configuration and Page Object Models
 import * as env from '../../src/config/world';
-// Imports Login Page functionality
 import { LoginPage } from '../../src/pages/common/LoginPage';
-// Imports Assignment Page functionality
-import { AssignmentPage } from '../../src/pages/admin/AssignmentPage';   
+import { AssignmentPage } from '../../src/pages/admin/AssignmentPage';
 import { AdminDashboardPage } from '../../src/pages/admin/AdminDashboardPage';
 
 let assignmentPage: AssignmentPage;
 
+// Test data
+const studentText = 'Ashlynn Marie';
+const studentName = 'Ashlynn Marie';
+
+const mentorText = 'ashl3yy.mari3+mentor01@gmail.com';
 
 test.describe('Mentor Assignments', () => {
-  test.beforeEach(async ({ page }) => {
-    // Initialize LoginPage, sign in as Admin, only runs before hook with appropriate tag THIS DOES NOT EFFECT
-    const loginPage = new LoginPage(page);
-    await page.goto(env.getBaseUrl());
-    await loginPage.loginAsUserType('Admin');
-    // Wait for the dashboard header to appear
-    const dashboardPage = new AdminDashboardPage(page);
-    await dashboardPage.waitForDashboard();
-    // Navigate to the Mentor Assignments section
-    await page.goto(`${env.getBaseUrl()}/admin/mentor-assignments`);
-    // Initiate AssignmentPage
-   
-  });
+    test.beforeEach(async ({ page }) => {
+        const loginPage = new LoginPage(page);
 
-  test(' Mentor-Student Assignments - the system should allow administrators to link students with mentors to ensure proper mentorship assignments.', async ({ page }) => {
-//     Scenario: Successful creation of a mentor-student assignment
-//       Given an admin is authorized to manage mentor-student assignments
-//       When the admin creates a new assignment with a valid mentor and student selected
-//       Then the system confirms successful creation
-//       And the new mentor-student pairing is displayed in the assignments list
-//       And an admin is authorized to manage mentor-student assignments
-//       And the admin creates a new assignment with a valid mentor and student selected
-//       Then the system confirms successful creation
-//       And the new mentor-student pairing is displayed in the assignments list
-    // Assertions use the expect API.
-    assignmentPage = new AssignmentPage(page);
-    await expect(page).toHaveURL(/mentor-assignments/);
-    // Create a new mentor-student assignment
-    await assignmentPage.assignStudentToMentor(
-    'Eric Hibbard Student (eric.hibbard91+student@gmail.com)',
-    'Eric Hibbard (eric.hibbard91+mentor@gmail.com)'); 
-    // Verify that the assignment was created successfully
-    await assignmentPage.verifyAssignmentCreated();  
-    // Verify that the new assignment appears in the assignments list
-    await assignmentPage.verifyDisplay();
-    // Remove assignment after each test to maintain test isolation
-    await assignmentPage.removeAssignment('Eric Hibbard Student');
-    // Check Assignment Issues Feature Steps
-    await expect(page).toHaveURL(/mentor-assignments/);
-     // Access incomplete info tool
-    let assignmentResult = await assignmentPage.checkAssignmentIssues(
-        'Eric Hibbard Student', 'Eric Hibbard'
-    );
-    if (assignmentResult === 'all-complete') {
-        // Skip verification because nothing was assigned
-        return;
-    }
-    await assignmentPage.verifyAssignmentIssue();
-    await assignmentPage.removeAssignment('Eric Hibbard Student');
-  });
+        await page.goto(env.getBaseUrl());
+        await loginPage.loginAsUserType('Admin');
 
-  test('Assignment Table Loads with the correct row of Mentor/Student/Status/Date', async ({ page }) => {
-    // Scenario: Assignment table loads successfully with data
-    // Given the admin is logged into the system to test assignment
-    // And the admin navigates to the Assignments page
-    // When the assignment table loads
-    // Then the system displays all existing mentor-student assignments
-    // And each row includes the mentor name, student name, status, and date assigned
-    const loginPage = new LoginPage(page);
-    await page.goto(env.getBaseUrl());
-    await loginPage.loginAsUserType('Admin');
-    // Wait for the dashboard header to appear
-    const dashboardPage = new AdminDashboardPage(page);
-    await dashboardPage.waitForDashboard();
+        const dashboardPage = new AdminDashboardPage(page);
+        await dashboardPage.waitForDashboard();
 
-     await page.goto(`${env.getBaseUrl()}/admin/mentor-assignments`);
-    // Initiate AssignmentPage
-    assignmentPage = new AssignmentPage(page);
-    await expect(page).toHaveURL(/mentor-assignments/);
+        await page.goto(`${env.getBaseUrl()}/admin/mentor-assignments`);
 
-    // Wait for the table to load
-    await page.waitForSelector('table');
-    // Verify that table displays existing assignments
-    await assignmentPage.verifyTableDisplay();
-   
-    // Verify that the table contains the correct columns
-    await assignmentPage.verifyColumnHeaders();
-  });
+        assignmentPage = new AssignmentPage(page);
 
+        await expect(page).toHaveURL(/mentor-assignments/);
+    });
+
+    test.afterEach(async ({ page, browserName }) => {
+        // Only the create-assignment test changes shared test data,
+        // and that test only runs in Chromium.
+        if (browserName !== 'chromium') {
+            return;
+        }
+
+        assignmentPage = new AssignmentPage(page);
+
+        await page.goto(`${env.getBaseUrl()}/admin/mentor-assignments`);
+
+        await assignmentPage.removeAssignmentIfExists(studentName);
+    });
+
+    test('Mentor-Student Assignments - the system should allow administrators to link students with mentors to ensure proper mentorship assignments.', async ({ page, browserName }) => {
+        test.skip(browserName !== 'chromium', 'Create assignment test uses shared student data, so run only in Chromium.');
+
+        await assignmentPage.assignStudentToMentor(studentText, mentorText);
+
+        await assignmentPage.verifyAssignmentCreated();
+
+        await assignmentPage.verifyDisplay(studentName);
+
+        await expect(page).toHaveURL(/mentor-assignments/);
+    });
+
+    test('Assignment Table Loads with the correct row of Mentor/Student/Status/Date', async ({ page }) => {
+        await expect(page).toHaveURL(/mentor-assignments/);
+
+        await page.waitForSelector('table');
+
+        await assignmentPage.verifyTableDisplay();
+
+        await assignmentPage.verifyColumnHeaders();
+    });
 });
-
-
-
-
-    

--- a/ui_tests/tests/mentor/mentorAssignments.spec.ts
+++ b/ui_tests/tests/mentor/mentorAssignments.spec.ts
@@ -6,11 +6,9 @@ import { AssignmentPage } from '../../src/pages/admin/AssignmentPage';
 import { AdminDashboardPage } from '../../src/pages/admin/AdminDashboardPage';
 
 let assignmentPage: AssignmentPage;
+let createdStudentName = '';
 
 // Test data
-const studentText = 'Ashlynn Marie';
-const studentName = 'Ashlynn Marie';
-
 const mentorText = 'ashl3yy.mari3+mentor01@gmail.com';
 
 test.describe('Mentor Assignments', () => {
@@ -37,21 +35,28 @@ test.describe('Mentor Assignments', () => {
             return;
         }
 
+        // Only try to remove if the test actually created an assignment.
+        if (!createdStudentName) {
+            return;
+        }
+
         assignmentPage = new AssignmentPage(page);
 
         await page.goto(`${env.getBaseUrl()}/admin/mentor-assignments`);
 
-        await assignmentPage.removeAssignmentIfExists(studentName);
+        await assignmentPage.removeAssignmentIfExists(createdStudentName);
+
+        createdStudentName = '';
     });
 
     test('Mentor-Student Assignments - the system should allow administrators to link students with mentors to ensure proper mentorship assignments.', async ({ page, browserName }) => {
         test.skip(browserName !== 'chromium', 'Create assignment test uses shared student data, so run only in Chromium.');
 
-        await assignmentPage.assignStudentToMentor(studentText, mentorText);
+        createdStudentName = await assignmentPage.assignFirstAvailableStudentToMentor(mentorText);
 
         await assignmentPage.verifyAssignmentCreated();
 
-        await assignmentPage.verifyDisplay(studentName);
+        await assignmentPage.verifyDisplay(createdStudentName);
 
         await expect(page).toHaveURL(/mentor-assignments/);
     });


### PR DESCRIPTION
## Summary
This PR fixes and stabilizes the Mentor Assignments Playwright tests by updating page object locators, improving assignment cleanup, and handling shared test data more safely.

Changes include:
- Updated dashboard greeting validation to support dynamic greeting text.
- Improved student and career coach dropdown selectors.
- Added cleanup logic to remove assigned students when needed.
- Updated table header validation from `Mentor` to `Career Coach`.
- Limited the create-assignment test to Chromium because it uses shared student data.
- Updated `dotenv` dependency to version `17.4.2`.

## Ticket
Closes #

## Change Type
- [ ] New test
- [x] Test fix
- [x] Framework/config update
- [ ] Docs update

## Risk & Impact
Low/Medium: Changes are limited to Mentor Assignment Playwright tests, related page objects, and the dotenv dependency update. The create-assignment test is limited to Chromium to avoid shared test data conflicts across browsers.

## Verification
- [x] Playwright/UI run
- [ ] API/Integration run
- [x] Manual check
- [ ] Other: ___

Evidence:
- Ran mentor assignment test suite locally:
  - `npx playwright test ui_tests/tests/mentor/mentorAssignments.spec.ts --workers=1`
- Latest result: `4 passed, 2 skipped`

## Checklist
- [x] I have merged the latest changes from `main` into my branch.
- [x] My code follows the project's style guidelines and branching conventions.
- [x] I have added comments to my code where necessary, particularly in hard-to-understand areas.
- [x] Self-review complete
- [x] All existing automated tests pass successfully with my changes locally.
